### PR TITLE
Bump MSBBarChart version to `2.0.0`

### DIFF
--- a/MSBBarChart.podspec
+++ b/MSBBarChart.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |spec|
   spec.name         = "MSBBarChart"
-  spec.version      = "1.1.2"
+  spec.version      = "2.0.0"
   spec.summary      = "MSBBarChart is an easy to use bar chart library for iOS"
   spec.homepage     = "https://github.com/misyobun/MSBBarChart"
   spec.screenshots  = "https://user-images.githubusercontent.com/509448/73722607-38024600-476a-11ea-8806-cc4a9245ffd8.gif"


### PR DESCRIPTION
## Summary

Bump MSBBarChart version to `2.0.0`.

This release version reflects the previously merged SwiftUI support and Sample app updates, including the SPM minimum iOS version change to iOS 13.

## Changes

- Updated `MSBBarChart.podspec`
  - `1.1.2` → `2.0.0`

## Breaking Change

- This release is versioned as `2.0.0` because the previously merged SwiftUI support changed the Swift Package minimum iOS version from iOS 12 to iOS 13.
- Existing UIKit APIs remain available.

## Verification

Confirmed the old version string no longer remains:

```bash
rg "1\\.1\\.2|2\\.0\\.0" MSBBarChart.podspec README.md Package.swift